### PR TITLE
Remove dependency on `unstable-list-lib`

### DIFF
--- a/logbook/private/raco-logbook-serve.rkt
+++ b/logbook/private/raco-logbook-serve.rkt
@@ -1,6 +1,5 @@
 #lang racket/base
 
-(require (only-in unstable/list group-by))
 (require racket/match)
 (require racket/date)
 (require racket/runtime-path)


### PR DESCRIPTION
Most of the functionality of that package will be moved into the core libraries by Racket PR #972, and `unstable-list-lib` will be removed from the main distribution.

This PR makes this package incompatible with Racket 6.2. To preserve compatibility, you can create a Racket 6.2-compatible branch in this repository and set up a version exception at pkgs.racket-lang.org

Even without the changes from this PR, this package will continue to work with future versions of Racket. It will, however, require installation of the `unstable-list-lib` package, as it will not be part of the main distribution in future versions.
